### PR TITLE
fix: ignorePathsに.node_versionを追加する

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,5 +13,6 @@
     "draftPR": true,
     "rebaseWhen": "never",
     "additionalBranchPrefix": "major/"
-  }
+  },
+  "ignorePaths": [".node_version"]
 }


### PR DESCRIPTION
## 背景
- https://github.com/avita-co-jp/avatar-diving-dashboard/pull/3803#issuecomment-2164264856
amplifyのビルド環境のnodeのバージョンが20.10.0までなのでrenovateからignoreする
