### PR TITLE
chore: devDependenciesの場合はbranchPrefixにno-chromaticを付与する

### DIFF
--- a/teams/avacom/renovate.json5
+++ b/teams/avacom/renovate.json5
@@ -13,6 +13,14 @@
 
   packageRules: [
     // -----------------------------
+    // devDependencies は全て Chromatic をスキップ
+    // -----------------------------
+    {
+      matchDepTypes: ["devDependencies"],
+      additionalBranchPrefix: "no-chromatic/",
+    },
+
+    // -----------------------------
     // patch は広くまとめて自動マージ
     // -----------------------------
     {


### PR DESCRIPTION
- https://github.com/avita-co-jp/avacom-issues/issues/2639

`no-chromatic/no-chromatic/`のように重複しないか調べたが、そのような記載は見つけられなかった。

branchNameは`"{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}"`から構成されるもので、
https://docs.renovatebot.com/configuration-options/#branchname

additionalBranchPrefixはstringなので、最終的にマッチした条件のadditionalBranchPrefixが使用されそう
https://docs.renovatebot.com/configuration-options/#additionalbranchprefix



