### PR TITLE
chore: storybook-react-i18nextをUI影響大パッケージに追加する

### DIFF
--- a/teams/avacom/renovate.json5
+++ b/teams/avacom/renovate.json5
@@ -36,12 +36,12 @@
     },
 
     // ------------------------------------------------------------
-    // minor：UI 影響“少”のスタックは週末にバッチでまとめる
+    // minor：UI 影響"少"のスタックは週末にバッチでまとめる
     // ------------------------------------------------------------
     {
       matchUpdateTypes: ["minor"],
       excludePackageNames: [
-        // 下の「UI影響“大”」グループで扱うものは除外
+        // 下の「UI影響"大"」グループで扱うものは除外
         "react",
         "react-dom",
         "next",
@@ -52,6 +52,7 @@
         "@radix-ui/*",
         "lucide-react",
         "shadcn-ui",
+        "storybook-react-i18next",
       ],
       groupName: "minor-batch-weekend",
       schedule: ["every weekend"], // 週末にバッチ
@@ -64,7 +65,7 @@
       draftPR: false,
     },
     // ------------------------------------------------------------
-    // minor：UI 影響“大”のライブラリは個別でPRを出す
+    // minor：UI 影響"大"のライブラリは個別でPRを出す
     // ------------------------------------------------------------
     {
       matchUpdateTypes: ["minor"],
@@ -79,6 +80,7 @@
         "@radix-ui/*",
         "lucide-react",
         "shadcn-ui",
+        "storybook-react-i18next",
       ],
       automerge: true,
       reviewers: [


### PR DESCRIPTION
## 背景

- https://github.com/avita-co-jp/avacom-issues/issues/3086
- https://github.com/avita-co-jp/add-manager-front/pull/1551

`storybook-react-i18next` は Storybook の i18n アドオンで、UI に影響を与えるため、minor アップデート時に Chromatic を実行する対象に追加します。

## 変更内容

- `excludePackageNames`（minor-batch-weekend）に追加: バッチまとめから除外
- `matchPackageNames`（minor UI影響大）に追加: 個別PR + Chromatic 実行対象
- コメント内のスマートクォート（U+201C/U+201D）をストレートクォートに修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)