### PR TITLE
chore: automerge GitHub Actions digest pinning

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,6 +9,15 @@
   "minor": {
     "additionalBranchPrefix": "minor/"
   },
+  "packageRules": [
+    {
+      "description": "Automerge GitHub Actions digest pinning",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["pinDigest"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ],
   "major": {
     "draftPR": true,
     "rebaseWhen": "never",


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクエストをレビューしてコメントする際には日本語でお願いします -->


## 背景 / Background

AVACOM front repos では GitHub Actions workflow の `uses:` を digest pin する運用に寄せていますが、Renovate が作成する pin PR は手動 merge が必要になっています。

digest pin はタグ/ブランチ参照を特定 SHA に固定する安全側の変更のため、CI が通ることと参照先 repo を信頼していることを前提に auto merge 対象とします。

## 実装の概要 / Implementation overview

- GitHub Actions の digest pin PR のみ Renovate auto merge 対象にします
- 共通 Renovate config の `default.json` に `matchManagers: ["github-actions"]` + `matchUpdateTypes: ["pinDigest"]` の packageRule を追加します
- `.github/workflows/**` が CODEOWNERS 対象でも、Renovate approve が有効なため branch protection bypass は不要見込みです
- reusable workflow の `@develop` などを pin する場合は、参照先 repo の現在の実体 SHA に固定される点に注意します

Related Issue:

- https://github.com/avita-co-jp/avacom-issues/issues/3607


## 開発ルール

- _[Github の基本運用方針](https://avita.kibe.la/notes/808) / Basic operation policy of Github_
- _[開発着手〜マージまでのフロントエンドレビューフロー](https://avita.kibe.la/notes/843) / Front-end review flow_

<!-- I want to review in Japanese. -->
<!-- for GitHub Copilot review rule -->
<!--
- 命名が分かりやすいこと
- 早期リターンすること
- 不要な useEffect を使用していないこと
- Enum ではなく Union 型を使うこと
- 基本的に null ではなく undefined を使うこと
- Component の props に Style を渡さないこと
- 最低限、命令網羅（C0）を守ること

レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo] (in my opinion)
[nits](nitpick)
[ask]
[fyi]
-->
<!-- for GitHub Copilot review  rule-->
<!-- I want to review in Japanese. -->
