### PR TITLE
Automerge GitHub Actions digest updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,9 +11,9 @@
   },
   "packageRules": [
     {
-      "description": "Automerge GitHub Actions digest pinning",
+      "description": "Automerge GitHub Actions digest updates",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["pinDigest"],
+      "matchUpdateTypes": ["digest", "pinDigest"],
       "automerge": true,
       "automergeType": "pr"
     }


### PR DESCRIPTION
## What changed

- Add `digest` to the GitHub Actions Renovate rule's `matchUpdateTypes`
- Keep `pinDigest` so initial SHA pinning remains covered
- Rename the rule description to reflect both cases

## Why

PR avita-co-jp/avatar-diving-dashboard#6339 updates an already pinned GitHub Actions SHA. Renovate classifies this as a `digest` update rather than `pinDigest`, so the existing rule did not enable automerge.

After this change, both initial digest pinning and subsequent digest updates for the `github-actions` manager are eligible for automerge.

## Validation

- Confirmed `default.json` remains valid JSON
- Change is limited to the relevant Renovate package rule

Reference: https://github.com/avita-co-jp/avatar-diving-dashboard/pull/6339