### PR TITLE
Group digest updates

### DIFF
--- a/teams/avacom/renovate.json5
+++ b/teams/avacom/renovate.json5
@@ -36,6 +36,21 @@
       additionalBranchPrefix: "no-chromatic/",
     },
 
+    // -----------------------------
+    // digest 更新はまとめて自動マージ
+    // -----------------------------
+    {
+      matchUpdateTypes: ["digest", "pinDigest"],
+      groupName: "digest-all",
+      automerge: true,
+      draftPR: false,
+      reviewers: [
+        "team:avita_avacom_frontend",
+        "team:fulltime_avacom_frontend",
+      ],
+      additionalBranchPrefix: "no-chromatic/",
+    },
+
     // ------------------------------------------------------------
     // minor：UI 影響"少"のスタックは週末にバッチでまとめる
     // ------------------------------------------------------------

--- a/teams/avacom/renovate.json5
+++ b/teams/avacom/renovate.json5
@@ -37,7 +37,7 @@
     },
 
     // -----------------------------
-    // digest 更新はまとめて自動マージ
+    // digest / pinDigest 更新はまとめて自動マージ
     // -----------------------------
     {
       matchUpdateTypes: ["digest", "pinDigest"],


### PR DESCRIPTION
## 変更内容

- `digest` と `pinDigest` の更新を `digest-all` グループにまとめるルールを追加
- 既存の patch 更新と同様に、自動マージ・レビュアー・Chromatic スキップ設定を適用

## 目的

Docker イメージや GitHub Actions などの digest 更新が個別 PR になるのを避け、週末の Renovate 更新をまとめて扱いやすくします。

## 関連ドキュメント

- [`packageRules.matchUpdateTypes`](https://docs.renovatebot.com/configuration-options/#packagerulesmatchupdatetypes)
  - `digest` と `pinDigest` を含む、更新種別によるルールのマッチング
- [`groupName`](https://docs.renovatebot.com/configuration-options/#groupname)
  - 同じ `groupName` にマッチした更新を同一ブランチ・PRへまとめる設定

## 確認

- 既存の JSON5 構造と packageRules の書式に合わせて追加
- 設定ファイルのみの変更