### PR TITLE
npmパッケージのminimum release ageを14日に設定する

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,11 @@
   },
   "packageRules": [
     {
+      "description": "Wait 14 days before updating npm packages",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "14 days"
+    },
+    {
       "description": "Automerge GitHub Actions digest updates",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["digest", "pinDigest"],

--- a/teams/avacom/renovate.json5
+++ b/teams/avacom/renovate.json5
@@ -1,7 +1,6 @@
 {
   prConcurrentLimit: 5, // 同時オープンPR数を制限
   prHourlyLimit: 5, // 1時間あたりの新規PR作成を制限
-  stabilityDays: 2, // 2日寝かせてからPR（即時リリースの不具合を吸収）
   separateMinorPatch: true, // patch と minor は必ず分離
   separateMultipleMajor: true, // major が複数同時に来ても一括にしない
   schedule: ["every weekend"], // 週末にバッチ


### PR DESCRIPTION
## Related Issue
- https://github.com/avita-co-jp/avacom-issues/issues/3786
- https://docs.renovatebot.com/configuration-options/#minimumreleaseage

## What
- npm datasource に `minimumReleaseAge: "14 days"` を追加
- 公開から14日未満のnpmパッケージをRenovateの更新候補から除外

## Why
Shai-Huludのようなサプライチェーン攻撃に対し、新規公開直後のnpmパッケージがRenovate経由で取り込まれるリスクを下げるため。

## Notes
- GitHub Actionsのdigest更新ルールには影響しない
- CI側の強制は core-web-frontend の別PRでSafe Chainに設定